### PR TITLE
Fix for supporting safe errors on corrupted PNG files.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -68,7 +68,7 @@ Parser.prototype._handleError = function() {
 
     this.destroy();
 
-    if (this._inflate)
+    if (this._inflate && (typeof this._inflate.destroy === 'function'))
         this._inflate.destroy();
 };
 


### PR DESCRIPTION
Fix for supporting safe errors on corrupted PNG files.

Actually, when a png file is corrupted the following fatal error is
thrown:

TypeError: Object #<Inflate> has no method 'destroy'

instead of emit a regular ’error’.